### PR TITLE
Clone obj before converting to snake_case

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -221,6 +221,7 @@ function toCamel(obj) {
 }
 
 function toSnake(obj) {
+  if (!obj) return;
   // Make a copy to avoid mutating source object
   const objCopy = JSON.parse(JSON.stringify(obj));
   return normalizeKeys(objCopy, 'snake');

--- a/lib/api.js
+++ b/lib/api.js
@@ -221,7 +221,9 @@ function toCamel(obj) {
 }
 
 function toSnake(obj) {
-  return normalizeKeys(obj, 'snake');
+  // Make a copy to avoid mutating source object
+  const objCopy = JSON.parse(JSON.stringify(obj));
+  return normalizeKeys(objCopy, 'snake');
 }
 
 function trimBoth(str) {


### PR DESCRIPTION
The `normalizeKeys` method provided by 'object-keys-normalizer' mutates the passed object directly, which is an undesirable side effect if the dev is using camelCase. Converting their original object to snake_case can result in unexpected errors, so we should clone it first. Since we are converting the object for an http request anyway, using JSON.stringify/parse should be safe here. 